### PR TITLE
Support logical nodes

### DIFF
--- a/pkg/core/src/jsx.ts
+++ b/pkg/core/src/jsx.ts
@@ -5,4 +5,10 @@ export const jsx: JSXPragma = (type, props, ...children) =>
     ? type(props ?? {}, children)
     : h(type, props, children);
 
-export const Fragment = (_props: any, children: any) => children
+export const Fragment: FragmentPragma = (props, children) => ({
+  props,
+  children,
+  key: props?.key,
+  init: props?.init,
+  listener: props?.listener,
+})

--- a/pkg/core/src/types.d.ts
+++ b/pkg/core/src/types.d.ts
@@ -1,6 +1,7 @@
 // Utils
 type HyperScript = (type: string, props?: VProps, ...children: VChildNode[]) => VNode;
 type JSXPragma = (type: string | Component, props?: VProps, ...children: VChildNode[]) => VChildNode;
+type FragmentPragma = (props?: VProps, ...children: VChildNode[]) => VChildNode;
 
 // Generic
 type Falsy = false | null | undefined;
@@ -51,8 +52,10 @@ interface VNode {
   text?: TextElement;
   key?: string;
   init?: Action;
+  cleanup?: Action;
   listener?: Listener;
   el?: Node;
+  oldChildren?: VNode[];
 }
 
 type ListenerCleanupFunction = () => void;


### PR DESCRIPTION
Finally, "fragment" support 🎉

Took a lot of trial-errors with different approaches, but you can now have vNodes with no `type` attribute, ex:
```

// This is a "node" with no "type" field, but you can still use other fields like `init`, `key`, `cleanup`, `listener`
const app = {
  init: { foo: 'hello' },
  children: state => <h1>{state.foo}</h1>
}

```